### PR TITLE
fix: fix heading font-size and responsive behavior with whitespace-no…

### DIFF
--- a/src/components/Banner/mainbanner.tsx
+++ b/src/components/Banner/mainbanner.tsx
@@ -37,14 +37,10 @@ const BannerHero = () => {
           "md:justify-center md:items-start md:pl-[2.5rem] md:w-[80%]"
         )}
       >
-        <h2
+        <h1
           className={clsx(
-            "text-black font-montserrat font-bold mb-4 text-[20px] w-full leading-tight",
-            "mobileXLarger:leading-8",
-            "laptop:text-[32px]",
-            "mobileMini:text-[28px] desktop:text-[36px] desktop:leading-[36px]",
-            "desktopLarge:text-[56px] desktopLarge:pr-[40%] desktopLarge:leading-[56px]",
-            "whitespace-nowrap"
+            "text-black font-montserrat font-bold mb-4 text-[18px] tablet:text-[40px] mobileLarger:text-[35px] mobileMicro:text-[30px] w-full leading-tight",
+            "whitespace-normal mobileLarger:whitespace-nowrap"
           )}
         >
           <span className="text-[#54287B] font-bold">
@@ -56,7 +52,7 @@ const BannerHero = () => {
             Por um futuro mais{" "}
             <span className="text-[#A468E4] font-bold">justo</span>
           </span>
-        </h2>
+        </h1>
 
         <p
           className={clsx(


### PR DESCRIPTION
# Corrigir a responsividade e font-size  do texto do banner seguindo os tamanhos do design: 
No design ele mantém o tamanho 40px na maior parte das telas, apenas na menor tela (dispositivos de width: 280px) ele altera para 18px. 
Como no código em telas de até 760px ele ainda mantém o layout de coluna nessa section, achei que colocar o texto para mudar para 18px logo quando o layout fica assim, o texto ficaria muito pequeno pra uma tela de 760px, por isso coloquei o tamanho da fonte para mdudar mais  gradualmente, indo de 18px para 30 - 35 - 40 ao invés de pular de 18 para 40
Além do tamanho das fontes também utilizei o whitespace-normal nas telas pequenas para corrigir o texto que ficava "saindo" da tela.
O texto principal do banner estava como uma tag `<h2>` , modifiquei para `<h1>` , acho que faz mais sentido por ser o texto do banner principal e também porque do jeito que estava antes a página não tinha nenhum h1